### PR TITLE
Add curator configuration loader

### DIFF
--- a/curator/__init__.py
+++ b/curator/__init__.py
@@ -1,0 +1,4 @@
+"""Curator package initialization."""
+
+__all__ = ("__version__",)
+__version__ = "0.1.0"

--- a/curator/config.py
+++ b/curator/config.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from pathlib import Path
+import tomllib
+from typing import List
+
+
+@dataclass
+class Config:
+    """Configuration values for curator."""
+
+    daily_candidates: int = 30
+    min_seconds: int = 5
+    max_seconds: int = 18_000  # 5 hours
+    seed_keywords: List[str] = field(default_factory=list)
+    download_cap_gb: int = 50
+    rps_limit: float = 1.0
+
+
+DEFAULT_CONFIG = Config(
+    seed_keywords=["funny", "crazy", "interesting"],
+)
+
+
+def load_config() -> Config:
+    """Return configuration merged with ``~/.curator/config.toml`` if present."""
+
+    path = Path.home() / ".curator" / "config.toml"
+    if path.is_file():
+        with path.open("rb") as f:
+            data = tomllib.load(f)
+    else:
+        data = {}
+
+    cfg_dict = dataclasses.asdict(DEFAULT_CONFIG)
+    cfg_dict.update({k: v for k, v in data.items() if k in cfg_dict})
+
+    return Config(**cfg_dict)


### PR DESCRIPTION
## Summary
- add `curator/` package skeleton with version stub
- implement `curator.config` for default settings
- load `~/.curator/config.toml` and merge with defaults

## Testing
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_6861d20d8e3c83319d8da6dcba9a673e