### PR TITLE
Add sentence-transformers recommender

### DIFF
--- a/curator/recommend.py
+++ b/curator/recommend.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import List, Dict
+
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+from . import db
+
+# Embedding model (384-dim)
+MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+_model = SentenceTransformer(MODEL)
+
+
+def embed(text: str) -> np.ndarray:
+    """Return normalized 384-dimensional embedding for ``text``."""
+    return _model.encode(text, convert_to_numpy=True, normalize_embeddings=True)
+
+
+def recommend(top_n: int) -> List[dict]:
+    """Return ``top_n`` items ranked by similarity to user preferences."""
+    with db.get_connection() as conn:
+        items = conn.execute("SELECT id, title, description FROM items").fetchall()
+        rated_rows = conn.execute("SELECT item_id, rating FROM ratings").fetchall()
+
+    # Aggregate ratings per item
+    rating_sum: Dict[str, float] = {}
+    rating_count: Dict[str, int] = {}
+    for row in rated_rows:
+        item_id = row["item_id"]
+        rating_sum[item_id] = rating_sum.get(item_id, 0.0) + row["rating"]
+        rating_count[item_id] = rating_count.get(item_id, 0) + 1
+
+    # Embed all items on demand
+    embeddings: Dict[str, np.ndarray] = {}
+    for item in items:
+        text = f"{item['title']} {item['description'] or ''}".strip()
+        embeddings[item["id"]] = embed(text)
+
+    dim = _model.get_sentence_embedding_dimension()
+    preference = np.zeros(dim, dtype=float)
+    weight_total = 0.0
+    for item_id, total_rating in rating_sum.items():
+        vec = embeddings.get(item_id)
+        if vec is None:
+            continue
+        weight = total_rating / rating_count[item_id]
+        preference += vec * weight
+        weight_total += weight
+    if weight_total:
+        preference /= weight_total
+    norm = np.linalg.norm(preference) or 1.0
+    preference /= norm
+
+    scored = [(float(np.dot(embeddings[row["id"]], preference)), row) for row in items]
+    scored.sort(key=lambda x: x[0], reverse=True)
+
+    return [row for _, row in scored[:top_n]]


### PR DESCRIPTION
## Summary
- implement recommender utility using MiniLM model
- expose embed(text) helper
- rank items by cosine similarity to rating-weighted preference vector

## Testing
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_6861d72f65888331b0c3d11b24e67627