### PR TITLE
Add click-based CLI and web UI

### DIFF
--- a/curator/cli.py
+++ b/curator/cli.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import click
+
+from . import db, fetch as fetch_module, recommend as recommend_module
+from .config import load_config
+
+
+@click.group()
+def cli() -> None:
+    """Curator command line interface."""
+    db.init_db()
+
+
+@cli.command()
+@click.option(
+    "-d",
+    "directory",
+    default="downloads",
+    type=click.Path(file_okay=False, dir_okay=True),
+)
+def fetch(directory: str) -> None:
+    """Fetch daily candidates and download them."""
+    cfg = load_config()
+    ids = fetch_module.fetch_candidates(cfg)
+    click.echo(f"Fetched {len(ids)} candidates")
+    for item_id in ids:
+        try:
+            path = fetch_module.download_item(item_id, directory, cfg)
+            click.echo(f"Downloaded {item_id} -> {path}")
+        except Exception as e:  # noqa: BLE001
+            click.echo(f"Failed {item_id}: {e}", err=True)
+
+
+@cli.command(name="list")
+@click.option("-n", default=10, help="number of items")
+def list_items(n: int) -> None:
+    """List recent items."""
+    rows = db.list_items(limit=n)
+    for row in rows:
+        click.echo(f"{row['id']} - {row['title']}")
+
+
+@cli.command()
+@click.argument("item_id")
+@click.argument("score", type=int)
+def rate(item_id: str, score: int) -> None:
+    """Record a rating for an item."""
+    db.record_rating(item_id, score)
+    click.echo(f"Rated {item_id} {score}")
+
+
+@cli.command()
+@click.option("-n", default=10, help="number of recommendations")
+def recommend(n: int) -> None:
+    """Print recommended items."""
+    rows = recommend_module.recommend(n)
+    for row in rows:
+        click.echo(f"{row['id']} - {row['title']}")
+
+
+@cli.command()
+def web() -> None:
+    """Run the Flask web UI."""
+    from . import web as web_module
+
+    app = web_module.create_app()
+    app.run(host="0.0.0.0", port=5000)
+
+
+if __name__ == "__main__":
+    cli()

--- a/curator/web.py
+++ b/curator/web.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from flask import Flask, render_template_string
+
+from . import db
+
+HTML = """
+<!doctype html>
+<title>Curator</title>
+<h1>Recent Items</h1>
+{% for item in items %}
+  <div>
+    <h3>{{ item['title'] }}</h3>
+    <p>{{ item['description'] or '' }}</p>
+    <video width="320" controls src="{{ item['url'] }}"></video>
+    <div>
+      {% for i in range(1, 11) %}
+        <form action="/rate/{{ item['id'] }}/{{ i }}" method="post" style="display:inline;">
+          <button type="submit">{{ i }}</button>
+        </form>
+      {% endfor %}
+    </div>
+  </div>
+  <hr>
+{% endfor %}
+"""
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    @app.get("/")
+    def index():
+        items = db.list_items(limit=20)
+        return render_template_string(HTML, items=items)
+
+    @app.post("/rate/<item_id>/<int:score>")
+    def rate(item_id: str, score: int):
+        db.record_rating(item_id, score)
+        return "", 204
+
+    return app
+
+
+def main() -> None:
+    create_app().run(host="0.0.0.0", port=5000)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,6 @@ mypy  = "^1.10.0"
 [build-system]
 requires = ["poetry-core>=1.5.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.scripts]
+curator = 'curator.cli:cli'


### PR DESCRIPTION
## Summary
- add `curator.cli` command group with fetch, list, rate, recommend and web subcommands
- implement simple Flask app in `curator.web`
- register `curator` entry point in poetry config

## Testing
- `poetry run black curator`
- `poetry run black curator --check`
- `python -m compileall -q curator`

------
https://chatgpt.com/codex/tasks/task_e_6861d8c45ec88331afcb4b95dedf95cf