### PR TITLE
Add templates and CORS

### DIFF
--- a/curator/db.py
+++ b/curator/db.py
@@ -117,6 +117,21 @@ def list_items(limit: int = 100, db_path: Path = DB_PATH) -> List[sqlite3.Row]:
         return cur.fetchall()
 
 
+def list_items_today(limit: int = 100, db_path: Path = DB_PATH) -> List[sqlite3.Row]:
+    """Return today's items ordered by ``added_at`` descending."""
+    with get_connection(db_path) as conn:
+        cur = conn.execute(
+            """
+            SELECT * FROM items
+            WHERE date(added_at, 'utc') = date('now','utc')
+            ORDER BY added_at DESC
+            LIMIT ?
+            """,
+            (limit,),
+        )
+        return cur.fetchall()
+
+
 def list_ratings(item_id: str, db_path: Path = DB_PATH) -> List[sqlite3.Row]:
     """Return all ratings for a given ``item_id``."""
     with get_connection(db_path) as conn:

--- a/curator/static/style.css
+++ b/curator/static/style.css
@@ -1,0 +1,2 @@
+body { font-family: sans-serif; }
+.rating form { margin-right: 4px; }

--- a/curator/templates/index.html
+++ b/curator/templates/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Curator</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <h1>Recent Items</h1>
+  {% for item in items %}
+  <div class="item">
+    <h3>{{ item['title'] }}</h3>
+    <p>{{ item['description'] or '' }}</p>
+    <video width="320" controls src="{{ item['url'] }}"></video>
+    <div class="rating">
+      {% for i in range(1, 11) %}
+        <form hx-post="/rate/{{ item['id'] }}/{{ i }}" hx-target="this" hx-swap="outerHTML" style="display:inline;">
+          <button type="submit">{{ i }}</button>
+        </form>
+      {% endfor %}
+    </div>
+  </div>
+  <hr>
+  {% endfor %}
+</body>
+</html>

--- a/curator/templates/rated_fragment.html
+++ b/curator/templates/rated_fragment.html
@@ -1,0 +1,1 @@
+<span>Rated {{ score }}</span>

--- a/curator/web.py
+++ b/curator/web.py
@@ -1,43 +1,24 @@
 from __future__ import annotations
 
-from flask import Flask, render_template_string
+from flask import Flask, render_template
+from flask_cors import CORS
 
 from . import db
 
-HTML = """
-<!doctype html>
-<title>Curator</title>
-<h1>Recent Items</h1>
-{% for item in items %}
-  <div>
-    <h3>{{ item['title'] }}</h3>
-    <p>{{ item['description'] or '' }}</p>
-    <video width="320" controls src="{{ item['url'] }}"></video>
-    <div>
-      {% for i in range(1, 11) %}
-        <form action="/rate/{{ item['id'] }}/{{ i }}" method="post" style="display:inline;">
-          <button type="submit">{{ i }}</button>
-        </form>
-      {% endfor %}
-    </div>
-  </div>
-  <hr>
-{% endfor %}
-"""
-
 
 def create_app() -> Flask:
-    app = Flask(__name__)
+    app = Flask(__name__, static_folder="static", template_folder="templates")
+    CORS(app)
 
     @app.get("/")
     def index():
-        items = db.list_items(limit=20)
-        return render_template_string(HTML, items=items)
+        items = db.list_items_today(limit=20)
+        return render_template("index.html", items=items)
 
     @app.post("/rate/<item_id>/<int:score>")
     def rate(item_id: str, score: int):
         db.record_rating(item_id, score)
-        return "", 204
+        return render_template("rated_fragment.html", score=score)
 
     return app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ flask = "^3.0.2"
 rich = "^13.7.0"
 tqdm = "^4.66.4"
 click = "^8.1.7"
+flask-cors = "^4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.0"


### PR DESCRIPTION
## Summary
- use flask templates and CORS
- add today's item query helper
- wire HTMX rate endpoint
- include static style sheet
- add flask-cors dependency

## Testing
- `make lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861da030ea08331b3141b89cdad122e