### PR TITLE
Add tests and test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ run-server: ## Serve Flask UI
 lint: ## Format with black
 	poetry run black curator
 
+test: ## Run unit tests
+	poetry run pytest -q
+
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ flask-cors = "^4.0.0"
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.0"
 mypy  = "^1.10.0"
+pytest = "^8.2.0"
 
 [build-system]
 requires = ["poetry-core>=1.5.0"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import sys
+
+# Add project root to sys.path for test imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Provide a minimal stub for the requests module if not installed
+if "requests" not in sys.modules:
+    import types
+
+    requests_stub = types.SimpleNamespace(get=None)
+    sys.modules["requests"] = requests_stub
+
+# Stub heavy optional dependencies so importing the package works
+if "numpy" not in sys.modules:
+    import types
+
+    numpy_stub = types.SimpleNamespace(
+        array=lambda *a, **k: None,
+        zeros=lambda *a, **k: 0,
+        dot=lambda *a, **k: 0,
+        linalg=types.SimpleNamespace(norm=lambda x: 0),
+    )
+    sys.modules["numpy"] = numpy_stub
+
+if "sentence_transformers" not in sys.modules:
+    import types
+
+    class DummyModel:
+        def encode(self, *a, **k):
+            return 0
+
+        def get_sentence_embedding_dimension(self):
+            return 1
+
+    sentence_stub = types.ModuleType("sentence_transformers")
+    sentence_stub.SentenceTransformer = lambda *a, **k: DummyModel()
+    sys.modules["sentence_transformers"] = sentence_stub

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,34 @@
+from click.testing import CliRunner
+from curator import db
+
+
+def setup_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "cli.db"
+    monkeypatch.setattr(db, "DB_PATH", db_path)
+    db.init_db(db_path)
+    db.insert_item("vid1", "title", "desc", 10, "url", db_path=db_path)
+
+    orig_init = db.init_db
+    orig_list = db.list_items
+    orig_record = db.record_rating
+    orig_insert = db.insert_item
+    monkeypatch.setattr(db, "init_db", lambda path=db_path: orig_init(path))
+    monkeypatch.setattr(db, "list_items", lambda limit=100, path=db_path: orig_list(limit, db_path=path))
+    monkeypatch.setattr(db, "record_rating", lambda item_id, rating, rated_at=None, path=db_path: orig_record(item_id, rating, rated_at, db_path=path))
+    monkeypatch.setattr(db, "insert_item", lambda *args, **kwargs: orig_insert(*args, db_path=db_path))
+
+    return db_path
+
+
+def test_cli_rate_and_list(monkeypatch, tmp_path):
+    setup_db(tmp_path, monkeypatch)
+    from curator.cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["rate", "vid1", "8"])
+    assert result.exit_code == 0
+    assert "Rated vid1 8" in result.output
+
+    result = runner.invoke(cli, ["list", "-n", "1"])
+    assert result.exit_code == 0
+    assert "vid1 - title" in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,27 @@
+import textwrap
+from pathlib import Path
+from curator.config import load_config, DEFAULT_CONFIG
+
+
+def test_load_config_without_user_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    cfg = load_config()
+    assert cfg == DEFAULT_CONFIG
+
+
+def test_load_config_with_user_file(monkeypatch, tmp_path):
+    cfg_dir = tmp_path / ".curator"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.toml").write_text(
+        textwrap.dedent(
+            """
+            daily_candidates = 5
+            seed_keywords = ["cats"]
+            """
+        )
+    )
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    cfg = load_config()
+    assert cfg.daily_candidates == 5
+    assert cfg.seed_keywords == ["cats"]
+    assert cfg.max_seconds == DEFAULT_CONFIG.max_seconds

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,17 @@
+from curator import db
+
+
+def test_db_insert_and_query(monkeypatch, tmp_path):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr(db, "DB_PATH", db_path)
+    db.init_db(db_path)
+
+    db.insert_item("vid1", "title", "desc", 10, "url", db_path=db_path)
+    items = db.list_items(db_path=db_path)
+    assert items
+    assert items[0]["id"] == "vid1"
+
+    db.record_rating("vid1", 7, db_path=db_path)
+    ratings = db.list_ratings("vid1", db_path=db_path)
+    assert ratings
+    assert ratings[0]["rating"] == 7

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,59 @@
+from curator import db
+from curator.config import Config
+
+
+class FakeResponse:
+    def __init__(self, json_data=None, status_code=200, content=b"data"):
+        self._json = json_data
+        self.status_code = status_code
+        self._content = content
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError("http error")
+
+    def iter_content(self, chunk_size=8192):
+        yield self._content
+
+
+def test_fetch_candidates(monkeypatch, tmp_path):
+    db_path = tmp_path / "fetch.db"
+    monkeypatch.setattr(db, "DB_PATH", db_path)
+    db.init_db(db_path)
+
+    orig_insert = db.insert_item
+    monkeypatch.setattr(db, "insert_item", lambda *args, **kwargs: orig_insert(*args, db_path=db_path))
+
+    from curator import fetch
+
+    def fake_get(url, params=None, stream=False):
+        if "advancedsearch" in url:
+            data = {
+                "response": {
+                    "docs": [
+                        {
+                            "identifier": "id1",
+                            "title": "Title",
+                            "description": "Desc",
+                            "duration": 10,
+                        }
+                    ]
+                }
+            }
+            return FakeResponse(data)
+        elif "metadata" in url:
+            return FakeResponse({"files": [{"name": "video.mp4", "format": "h.264", "size": "10"}]})
+        else:
+            raise RuntimeError("unexpected url" + url)
+
+    monkeypatch.setattr(fetch, "_sleep_for_rps", lambda x: None)
+    monkeypatch.setattr(fetch.requests, "get", fake_get)
+
+    cfg = Config(daily_candidates=1, seed_keywords=["x"], rps_limit=0)
+    ids = fetch.fetch_candidates(cfg)
+    assert ids == ["id1"]
+    items = db.list_items(db_path=db_path)
+    assert items[0]["id"] == "id1"


### PR DESCRIPTION
## Summary
- add pytest as a dev dependency
- provide `make test` target
- create unit tests for config, db, CLI and fetcher

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6861e0a832788331a4a446f90711c2d3