### PR TITLE
Add rating validation

### DIFF
--- a/curator/cli.py
+++ b/curator/cli.py
@@ -56,7 +56,12 @@ def list_items(n: int) -> None:
 @click.argument("score", type=int)
 def rate(item_id: str, score: int) -> None:
     """Record a rating for an item."""
-    db.record_rating(item_id, score)
+    try:
+        db.record_rating(item_id, score)
+    except ValueError as e:
+        logger.error("[!] %s", e)
+        click.echo(str(e), err=True)
+        raise SystemExit(1)
     logger.info("[i] rated %s %d", item_id, score)
     click.echo(f"Rated {item_id} {score}")
 

--- a/curator/db.py
+++ b/curator/db.py
@@ -80,6 +80,8 @@ def record_rating(
     db_path: Path = DB_PATH,
 ) -> None:
     """Record a rating for an item."""
+    if not 1 <= rating <= 10:
+        raise ValueError("rating must be between 1 and 10")
     with get_connection(db_path) as conn:
         conn.execute(
             """

--- a/curator/web.py
+++ b/curator/web.py
@@ -23,7 +23,11 @@ def create_app() -> Flask:
 
     @app.post("/rate/<item_id>/<int:score>")
     def rate(item_id: str, score: int):
-        db.record_rating(item_id, score)
+        try:
+            db.record_rating(item_id, score)
+        except ValueError as e:
+            logger.warning("[!] %s", e)
+            return str(e), 400
         logger.info("[i] rated %s %d via web", item_id, score)
         return render_template("rated_fragment.html", score=score)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,9 +13,19 @@ def setup_db(tmp_path, monkeypatch):
     orig_record = db.record_rating
     orig_insert = db.insert_item
     monkeypatch.setattr(db, "init_db", lambda path=db_path: orig_init(path))
-    monkeypatch.setattr(db, "list_items", lambda limit=100, path=db_path: orig_list(limit, db_path=path))
-    monkeypatch.setattr(db, "record_rating", lambda item_id, rating, rated_at=None, path=db_path: orig_record(item_id, rating, rated_at, db_path=path))
-    monkeypatch.setattr(db, "insert_item", lambda *args, **kwargs: orig_insert(*args, db_path=db_path))
+    monkeypatch.setattr(
+        db, "list_items", lambda limit=100, path=db_path: orig_list(limit, db_path=path)
+    )
+    monkeypatch.setattr(
+        db,
+        "record_rating",
+        lambda item_id, rating, rated_at=None, path=db_path: orig_record(
+            item_id, rating, rated_at, db_path=path
+        ),
+    )
+    monkeypatch.setattr(
+        db, "insert_item", lambda *args, **kwargs: orig_insert(*args, db_path=db_path)
+    )
 
     return db_path
 
@@ -32,3 +42,13 @@ def test_cli_rate_and_list(monkeypatch, tmp_path):
     result = runner.invoke(cli, ["list", "-n", "1"])
     assert result.exit_code == 0
     assert "vid1 - title" in result.output
+
+
+def test_cli_invalid_rating(monkeypatch, tmp_path):
+    setup_db(tmp_path, monkeypatch)
+    from curator.cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["rate", "vid1", "11"])
+    assert result.exit_code != 0
+    assert "between 1 and 10" in result.output

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,39 @@
+import pytest
+from curator import db
+from curator.web import create_app
+
+
+def setup_web_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "web.db"
+    monkeypatch.setattr(db, "DB_PATH", db_path)
+    db.init_db(db_path)
+    db.insert_item("vid1", "title", "desc", 10, "url", db_path=db_path)
+
+    orig_list = db.list_items_today
+    orig_record = db.record_rating
+    orig_insert = db.insert_item
+    monkeypatch.setattr(
+        db,
+        "list_items_today",
+        lambda limit=20, path=db_path: orig_list(limit, db_path=path),
+    )
+    monkeypatch.setattr(
+        db,
+        "record_rating",
+        lambda item_id, rating, rated_at=None, path=db_path: orig_record(
+            item_id, rating, rated_at, db_path=path
+        ),
+    )
+    monkeypatch.setattr(
+        db, "insert_item", lambda *args, **kwargs: orig_insert(*args, db_path=db_path)
+    )
+
+    return db_path
+
+
+def test_web_invalid_rating(monkeypatch, tmp_path):
+    setup_web_db(tmp_path, monkeypatch)
+    app = create_app()
+    with app.test_client() as client:
+        resp = client.post("/rate/vid1/0")
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- validate ratings in `record_rating`
- surface invalid rating errors in CLI and web
- test invalid ratings for CLI and web

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e84cc8e88331a18b9074140b8514