### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+# install Poetry
+RUN pip install --no-cache-dir poetry
+
+WORKDIR /app
+COPY . /app
+
+# install dependencies
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-interaction --no-ansi
+
+EXPOSE 5000
+CMD ["curator", "web"]

--- a/README.md
+++ b/README.md
@@ -14,13 +14,17 @@ either from a rich CLI or a zero-config Flask site on your LAN.
 * Sentence-Transformers embeddings (CUDA if available) for taste learning  
 * Robust `[i]/[!]/[DEBUG]/[x]` logging and WAL-backed SQLite  
 * Self-contained: only Python 3.12+, Requests, Flask, Sentence-Transformers  
-* Makefile + install.sh for one-shot bootstrap; Dockerfile coming v1.0
+* Makefile + install.sh for one-shot bootstrap; Dockerfile provided
 
 ## Quick-start
         ./install.sh                         # installs pipx → Poetry → deps
         make run-cli                          # run curator fetch
         make run-server                       # start Flask UI
         poetry run curator rate <IA_ID> 7     # CLI rating
+
+## Docker
+        docker build -t timetunnel .
+        docker run -p 5000:5000 timetunnel
 
 ## Directory layout
 project/


### PR DESCRIPTION
## Summary
- add Dockerfile using python:3.12-slim
- expose port 5000 and set curator web as default command
- document container usage instructions in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6863500744f483318090cdc3e9099343